### PR TITLE
Consolidate DRAM controller in AES_DRAM_Top

### DIFF
--- a/AES_DRAM_Top.v
+++ b/AES_DRAM_Top.v
@@ -120,54 +120,28 @@ module AES_DRAM_Top(
     wire [15:0] lim_in;
     wire [2:0]  demux_add [0:15];
     wire [5:0]  rwl_add   [0:15];
-
-    // Wires from DRAM controller to top-level pins (AES operation)
-    wire [16:1] aes_dram_din;
-    wire [16:1] aes_dram_rad;
-    wire [16:1] aes_dram_lim;
-    wire [1:0]  aes_lim_sel;
-    wire        aes_add_in_w;
-    wire        aes_add_vld_w;
-    wire        aes_data_vld_w;
-    wire        aes_clk_out_w;
-    wire        aes_wri_en_w;
-    wire        aes_rd_en_w;
-    wire        aes_vsaen_w;
-    wire        aes_ref_wwl_w;
-    wire        aes_dmx2_w;
-    wire [2:0]  aes_pc_data_w;
-    wire [1:0]  aes_pc_d_in_w;
-    wire [1:0]  aes_pc_r_ad_w;
+    // Wires driving the DRAM controller outputs
+    wire [16:1] dram_din_w;
+    wire [16:1] dram_rad_w;
+    wire [16:1] dram_lim_w;
+    wire [1:0]  lim_sel_w;
+    wire        add_in_w;
+    wire        add_vld_w;
+    wire        data_vld_w;
+    wire        clk_out_w;
+    wire        wri_en_w;
+    wire        rd_en_w;
+    wire        vsaen_w;
+    wire        ref_wwl_w;
+    wire        dmx2_w;
+    wire [2:0]  pc_data_w;
+    wire [1:0]  pc_d_in_w;
+    wire [1:0]  pc_r_ad_w;
 
     // Wires for key/SBOX initialization generator
     wire        init_io_en;
     wire [5:0]  init_addr;
     wire [63:0] init_wbl_data [0:15];
-
-    // Wires from initialization DRAM controller
-    wire [16:1] init_dram_din;
-    wire [16:1] init_dram_rad;
-    wire [16:1] init_dram_lim;
-    wire [1:0]  init_lim_sel;
-    wire        init_add_in_w;
-    wire        init_add_vld_w;
-    wire        init_data_vld_w;
-    wire        init_clk_out_w;
-    wire        init_wri_en_w;
-    wire        init_rd_en_w;
-    wire        init_vsaen_w;
-    wire        init_ref_wwl_w;
-    wire        init_dmx2_w;
-    wire [2:0]  init_pc_data_w;
-    wire [1:0]  init_pc_d_in_w;
-    wire [1:0]  init_pc_r_ad_w;
-    wire        init_cinh_ps_1v8;
-    wire        init_sr_ps_1v8;
-    wire        init_clk_ps_1v8;
-    wire        init_clrb_spw_1v8;
-    wire        init_clk_spw_1v8;
-    wire        init_clrb_spr_1v8;
-    wire        init_clk_spr_1v8;
     wire        init_done;
 
     // ------------------------------------------------------------------
@@ -208,66 +182,6 @@ module AES_DRAM_Top(
         .RWL_DEC_ADD_14(rwl_add[14]), .RWL_DEC_ADD_15(rwl_add[15]),
         .IN    (lim_in)
     );
-
-    // ------------------------------------------------------------------
-    // DRAM controller. It receives address and LIM signals from the AES
-    // core and returns serialized DRAM data which is then used by AES.
-    // Unused write channels are tied off.
-    // ------------------------------------------------------------------
-    DRAM_write_read_16core u_dram (
-        .clk          (CLK),
-        .rst_n        (RSTn),
-        .IO_EN        (EN && init_done),
-        .IO_MODEL     (2'b10), // read mode
-        .CIM_model    (2'b00),
-        .DATA_IN      (lim_in),
-        .WBL_DATA_IN1 (64'b0),  .WBL_DATA_IN2 (64'b0),
-        .WBL_DATA_IN3 (64'b0),  .WBL_DATA_IN4 (64'b0),
-        .WBL_DATA_IN5 (64'b0),  .WBL_DATA_IN6 (64'b0),
-        .WBL_DATA_IN7 (64'b0),  .WBL_DATA_IN8 (64'b0),
-        .WBL_DATA_IN9 (64'b0),  .WBL_DATA_IN10(64'b0),
-        .WBL_DATA_IN11(64'b0),  .WBL_DATA_IN12(64'b0),
-        .WBL_DATA_IN13(64'b0),  .WBL_DATA_IN14(64'b0),
-        .WBL_DATA_IN15(64'b0),  .WBL_DATA_IN16(64'b0),
-        .WWL_ADD      (6'b0),
-        .RWL_DEC_ADD1 (rwl_add[0]),  .RWL_DEC_ADD2 (rwl_add[1]),
-        .RWL_DEC_ADD3 (rwl_add[2]),  .RWL_DEC_ADD4 (rwl_add[3]),
-        .RWL_DEC_ADD5 (rwl_add[4]),  .RWL_DEC_ADD6 (rwl_add[5]),
-        .RWL_DEC_ADD7 (rwl_add[6]),  .RWL_DEC_ADD8 (rwl_add[7]),
-        .RWL_DEC_ADD9 (rwl_add[8]),  .RWL_DEC_ADD10(rwl_add[9]),
-        .RWL_DEC_ADD11(rwl_add[10]), .RWL_DEC_ADD12(rwl_add[11]),
-        .RWL_DEC_ADD13(rwl_add[12]), .RWL_DEC_ADD14(rwl_add[13]),
-        .RWL_DEC_ADD15(rwl_add[14]), .RWL_DEC_ADD16(rwl_add[15]),
-        .DEMUX_ADD1   (demux_add[0][1:0]),  .DEMUX_ADD2   (demux_add[1][1:0]),
-        .DEMUX_ADD3   (demux_add[2][1:0]),  .DEMUX_ADD4   (demux_add[3][1:0]),
-        .DEMUX_ADD5   (demux_add[4][1:0]),  .DEMUX_ADD6   (demux_add[5][1:0]),
-        .DEMUX_ADD7   (demux_add[6][1:0]),  .DEMUX_ADD8   (demux_add[7][1:0]),
-        .DEMUX_ADD9   (demux_add[8][1:0]),  .DEMUX_ADD10  (demux_add[9][1:0]),
-        .DEMUX_ADD11  (demux_add[10][1:0]), .DEMUX_ADD12  (demux_add[11][1:0]),
-        .DEMUX_ADD13  (demux_add[12][1:0]), .DEMUX_ADD14  (demux_add[13][1:0]),
-        .DEMUX_ADD15  (demux_add[14][1:0]), .DEMUX_ADD16  (demux_add[15][1:0]),
-        .DEMUX_ADD_3  (demux_add[0][2]),
-        .DRAM_DATA_OUT(dram_byte),
-        .RD_DONE      (rd_done),
-        .DRAM16_data  (DRAM16_data),
-        .PC_data      (aes_pc_data_w),
-        .ADD_IN       (aes_add_in_w),
-        .ADD_VALID_IN (aes_add_vld_w),
-        .PC_D_IN      (aes_pc_d_in_w),
-        .D_IN         (aes_dram_din),
-        .DATA_VALID_IN(aes_data_vld_w),
-        .clk_out      (aes_clk_out_w),
-        .WRI_EN       (aes_wri_en_w),
-        .R_AD         (aes_dram_rad),
-        .PC_R_AD      (aes_pc_r_ad_w),
-        .LIM_IN       (aes_dram_lim),
-        .LIM_SEL      (aes_lim_sel),
-        .DE_ADD3      (aes_dmx2_w),
-        .RD_EN        (aes_rd_en_w),
-        .VSAEN        (aes_vsaen_w),
-        .REF_WWL      (aes_ref_wwl_w)
-    );
-
     // Initialization data generator for round keys and SBOX
     DRAM_Key_Sbox_Init u_init (
         .CLK       (CLK),
@@ -286,104 +200,148 @@ module AES_DRAM_Top(
         .WBL_DATA15(init_wbl_data[14]), .WBL_DATA16(init_wbl_data[15])
     );
 
-    // DRAM controller instance used during initialization (write mode)
-    DRAM_write_read_16core u_dram_init (
-        .clk          (CLK),
-        .rst_n        (RSTn),
-        .IO_EN        (init_io_en),
-        .IO_MODEL     (2'b01), // write mode
-        .CIM_model    (2'b00),
-        .DATA_IN      (16'b0),
-        .WBL_DATA_IN1 (init_wbl_data[0]),   .WBL_DATA_IN2 (init_wbl_data[1]),
-        .WBL_DATA_IN3 (init_wbl_data[2]),   .WBL_DATA_IN4 (init_wbl_data[3]),
-        .WBL_DATA_IN5 (init_wbl_data[4]),   .WBL_DATA_IN6 (init_wbl_data[5]),
-        .WBL_DATA_IN7 (init_wbl_data[6]),   .WBL_DATA_IN8 (init_wbl_data[7]),
-        .WBL_DATA_IN9 (init_wbl_data[8]),   .WBL_DATA_IN10(init_wbl_data[9]),
-        .WBL_DATA_IN11(init_wbl_data[10]),  .WBL_DATA_IN12(init_wbl_data[11]),
-        .WBL_DATA_IN13(init_wbl_data[12]),  .WBL_DATA_IN14(init_wbl_data[13]),
-        .WBL_DATA_IN15(init_wbl_data[14]),  .WBL_DATA_IN16(init_wbl_data[15]),
-        .WWL_ADD      (init_addr),
-        .RWL_DEC_ADD1 (6'd0), .RWL_DEC_ADD2 (6'd0),
-        .RWL_DEC_ADD3 (6'd0), .RWL_DEC_ADD4 (6'd0),
-        .RWL_DEC_ADD5 (6'd0), .RWL_DEC_ADD6 (6'd0),
-        .RWL_DEC_ADD7 (6'd0), .RWL_DEC_ADD8 (6'd0),
-        .RWL_DEC_ADD9 (6'd0), .RWL_DEC_ADD10(6'd0),
-        .RWL_DEC_ADD11(6'd0), .RWL_DEC_ADD12(6'd0),
-        .RWL_DEC_ADD13(6'd0), .RWL_DEC_ADD14(6'd0),
-        .RWL_DEC_ADD15(6'd0), .RWL_DEC_ADD16(6'd0),
-        .DEMUX_ADD1   (2'd0), .DEMUX_ADD2   (2'd0),
-        .DEMUX_ADD3   (2'd0), .DEMUX_ADD4   (2'd0),
-        .DEMUX_ADD5   (2'd0), .DEMUX_ADD6   (2'd0),
-        .DEMUX_ADD7   (2'd0), .DEMUX_ADD8   (2'd0),
-        .DEMUX_ADD9   (2'd0), .DEMUX_ADD10  (2'd0),
-        .DEMUX_ADD11  (2'd0), .DEMUX_ADD12  (2'd0),
-        .DEMUX_ADD13  (2'd0), .DEMUX_ADD14  (2'd0),
-        .DEMUX_ADD15  (2'd0), .DEMUX_ADD16  (2'd0),
-        .DEMUX_ADD_3  (1'b0),
-        .DRAM_DATA_OUT(),
-        .RD_DONE      (),
-        .DRAM16_data  (16'b0),
-        .PC_data      (init_pc_data_w),
-        .ADD_IN       (init_add_in_w),
-        .ADD_VALID_IN (init_add_vld_w),
-        .PC_D_IN      (init_pc_d_in_w),
-        .D_IN         (init_dram_din),
-        .DATA_VALID_IN(init_data_vld_w),
-        .clk_out      (init_clk_out_w),
-        .WRI_EN       (init_wri_en_w),
-        .R_AD         (init_dram_rad),
-        .PC_R_AD      (init_pc_r_ad_w),
-        .LIM_IN       (init_dram_lim),
-        .LIM_SEL      (init_lim_sel),
-        .DE_ADD3      (init_dmx2_w),
-        .RD_EN        (init_rd_en_w),
-        .VSAEN        (init_vsaen_w),
-        .REF_WWL      (init_ref_wwl_w)
-    );
-
-    assign {init_cinh_ps_1v8, init_sr_ps_1v8, init_clk_ps_1v8} = init_pc_data_w;
-    assign {init_clrb_spw_1v8, init_clk_spw_1v8} = init_pc_d_in_w;
-    assign {init_clrb_spr_1v8, init_clk_spr_1v8} = init_pc_r_ad_w;
-
     // Select between initialization and normal AES operation
     wire init_active = ~init_done;
-    assign ADDIN_1v8   = init_active ? init_add_in_w   : aes_add_in_w;
-    assign ADVLD_1v8   = init_active ? init_add_vld_w  : aes_add_vld_w;
-    assign DVLD_1v8    = init_active ? init_data_vld_w : aes_data_vld_w;
-    assign CLK_chip_1v8 = init_active ? init_clk_out_w : aes_clk_out_w;
-    assign WRIEN_1v8   = init_active ? init_wri_en_w   : aes_wri_en_w;
-    assign RDEN_1v8    = init_active ? init_rd_en_w    : aes_rd_en_w;
-    assign VSAEN_1v8   = init_active ? init_vsaen_w   : aes_vsaen_w;
-    assign REFWWL_1v8  = init_active ? init_ref_wwl_w : aes_ref_wwl_w;
-    assign DMX2_1v8    = init_active ? init_dmx2_w    : aes_dmx2_w;
-    assign LIMSEL0_1v8 = init_active ? init_lim_sel[0]: aes_lim_sel[0];
-    assign LIMSEL1_1v8 = init_active ? init_lim_sel[1]: aes_lim_sel[1];
 
-    assign {CINH_ps_1v8, SR_ps_1v8, CLK_ps_1v8} =
-           init_active ? {init_cinh_ps_1v8, init_sr_ps_1v8, init_clk_ps_1v8}
-                        : aes_pc_data_w;
-    assign {CLRb_spw_1v8, CLK_spw_1v8} =
-           init_active ? {init_clrb_spw_1v8, init_clk_spw_1v8}
-                        : aes_pc_d_in_w;
-    assign {CLRb_spr_1v8, CLK_spr_1v8} =
-           init_active ? {init_clrb_spr_1v8, init_clk_spr_1v8}
-                        : aes_pc_r_ad_w;
+    // Mux DRAM controller inputs based on current mode
+    wire        io_en_sel       = init_active ? init_io_en        : (EN && init_done);
+    wire [1:0]  io_model_sel    = init_active ? 2'b01             : 2'b10;
+    wire [16:1] data_in_sel     = init_active ? 16'b0             : lim_in;
+    wire [63:0] wbl_data_in1    = init_active ? init_wbl_data[0]  : 64'b0;
+    wire [63:0] wbl_data_in2    = init_active ? init_wbl_data[1]  : 64'b0;
+    wire [63:0] wbl_data_in3    = init_active ? init_wbl_data[2]  : 64'b0;
+    wire [63:0] wbl_data_in4    = init_active ? init_wbl_data[3]  : 64'b0;
+    wire [63:0] wbl_data_in5    = init_active ? init_wbl_data[4]  : 64'b0;
+    wire [63:0] wbl_data_in6    = init_active ? init_wbl_data[5]  : 64'b0;
+    wire [63:0] wbl_data_in7    = init_active ? init_wbl_data[6]  : 64'b0;
+    wire [63:0] wbl_data_in8    = init_active ? init_wbl_data[7]  : 64'b0;
+    wire [63:0] wbl_data_in9    = init_active ? init_wbl_data[8]  : 64'b0;
+    wire [63:0] wbl_data_in10   = init_active ? init_wbl_data[9]  : 64'b0;
+    wire [63:0] wbl_data_in11   = init_active ? init_wbl_data[10] : 64'b0;
+    wire [63:0] wbl_data_in12   = init_active ? init_wbl_data[11] : 64'b0;
+    wire [63:0] wbl_data_in13   = init_active ? init_wbl_data[12] : 64'b0;
+    wire [63:0] wbl_data_in14   = init_active ? init_wbl_data[13] : 64'b0;
+    wire [63:0] wbl_data_in15   = init_active ? init_wbl_data[14] : 64'b0;
+    wire [63:0] wbl_data_in16   = init_active ? init_wbl_data[15] : 64'b0;
+    wire [5:0]  wwl_add_sel     = init_active ? init_addr         : 6'b0;
+    wire [5:0]  rwl_dec_add1    = init_active ? 6'd0              : rwl_add[0];
+    wire [5:0]  rwl_dec_add2    = init_active ? 6'd0              : rwl_add[1];
+    wire [5:0]  rwl_dec_add3    = init_active ? 6'd0              : rwl_add[2];
+    wire [5:0]  rwl_dec_add4    = init_active ? 6'd0              : rwl_add[3];
+    wire [5:0]  rwl_dec_add5    = init_active ? 6'd0              : rwl_add[4];
+    wire [5:0]  rwl_dec_add6    = init_active ? 6'd0              : rwl_add[5];
+    wire [5:0]  rwl_dec_add7    = init_active ? 6'd0              : rwl_add[6];
+    wire [5:0]  rwl_dec_add8    = init_active ? 6'd0              : rwl_add[7];
+    wire [5:0]  rwl_dec_add9    = init_active ? 6'd0              : rwl_add[8];
+    wire [5:0]  rwl_dec_add10   = init_active ? 6'd0              : rwl_add[9];
+    wire [5:0]  rwl_dec_add11   = init_active ? 6'd0              : rwl_add[10];
+    wire [5:0]  rwl_dec_add12   = init_active ? 6'd0              : rwl_add[11];
+    wire [5:0]  rwl_dec_add13   = init_active ? 6'd0              : rwl_add[12];
+    wire [5:0]  rwl_dec_add14   = init_active ? 6'd0              : rwl_add[13];
+    wire [5:0]  rwl_dec_add15   = init_active ? 6'd0              : rwl_add[14];
+    wire [5:0]  rwl_dec_add16   = init_active ? 6'd0              : rwl_add[15];
+    wire [1:0]  demux_add1      = init_active ? 2'd0              : demux_add[0][1:0];
+    wire [1:0]  demux_add2      = init_active ? 2'd0              : demux_add[1][1:0];
+    wire [1:0]  demux_add3      = init_active ? 2'd0              : demux_add[2][1:0];
+    wire [1:0]  demux_add4      = init_active ? 2'd0              : demux_add[3][1:0];
+    wire [1:0]  demux_add5      = init_active ? 2'd0              : demux_add[4][1:0];
+    wire [1:0]  demux_add6      = init_active ? 2'd0              : demux_add[5][1:0];
+    wire [1:0]  demux_add7      = init_active ? 2'd0              : demux_add[6][1:0];
+    wire [1:0]  demux_add8      = init_active ? 2'd0              : demux_add[7][1:0];
+    wire [1:0]  demux_add9      = init_active ? 2'd0              : demux_add[8][1:0];
+    wire [1:0]  demux_add10     = init_active ? 2'd0              : demux_add[9][1:0];
+    wire [1:0]  demux_add11     = init_active ? 2'd0              : demux_add[10][1:0];
+    wire [1:0]  demux_add12     = init_active ? 2'd0              : demux_add[11][1:0];
+    wire [1:0]  demux_add13     = init_active ? 2'd0              : demux_add[12][1:0];
+    wire [1:0]  demux_add14     = init_active ? 2'd0              : demux_add[13][1:0];
+    wire [1:0]  demux_add15     = init_active ? 2'd0              : demux_add[14][1:0];
+    wire [1:0]  demux_add16     = init_active ? 2'd0              : demux_add[15][1:0];
+    wire        demux_add_3     = init_active ? 1'b0              : demux_add[0][2];
+
+    // Single DRAM controller used for both initialization and AES operation
+    DRAM_write_read_16core u_dram (
+        .clk          (CLK),
+        .rst_n        (RSTn),
+        .IO_EN        (io_en_sel),
+        .IO_MODEL     (io_model_sel),
+        .CIM_model    (2'b00),
+        .DATA_IN      (data_in_sel),
+        .WBL_DATA_IN1 (wbl_data_in1),   .WBL_DATA_IN2 (wbl_data_in2),
+        .WBL_DATA_IN3 (wbl_data_in3),   .WBL_DATA_IN4 (wbl_data_in4),
+        .WBL_DATA_IN5 (wbl_data_in5),   .WBL_DATA_IN6 (wbl_data_in6),
+        .WBL_DATA_IN7 (wbl_data_in7),   .WBL_DATA_IN8 (wbl_data_in8),
+        .WBL_DATA_IN9 (wbl_data_in9),   .WBL_DATA_IN10(wbl_data_in10),
+        .WBL_DATA_IN11(wbl_data_in11),  .WBL_DATA_IN12(wbl_data_in12),
+        .WBL_DATA_IN13(wbl_data_in13),  .WBL_DATA_IN14(wbl_data_in14),
+        .WBL_DATA_IN15(wbl_data_in15),  .WBL_DATA_IN16(wbl_data_in16),
+        .WWL_ADD      (wwl_add_sel),
+        .RWL_DEC_ADD1 (rwl_dec_add1),   .RWL_DEC_ADD2 (rwl_dec_add2),
+        .RWL_DEC_ADD3 (rwl_dec_add3),   .RWL_DEC_ADD4 (rwl_dec_add4),
+        .RWL_DEC_ADD5 (rwl_dec_add5),   .RWL_DEC_ADD6 (rwl_dec_add6),
+        .RWL_DEC_ADD7 (rwl_dec_add7),   .RWL_DEC_ADD8 (rwl_dec_add8),
+        .RWL_DEC_ADD9 (rwl_dec_add9),   .RWL_DEC_ADD10(rwl_dec_add10),
+        .RWL_DEC_ADD11(rwl_dec_add11),  .RWL_DEC_ADD12(rwl_dec_add12),
+        .RWL_DEC_ADD13(rwl_dec_add13),  .RWL_DEC_ADD14(rwl_dec_add14),
+        .RWL_DEC_ADD15(rwl_dec_add15),  .RWL_DEC_ADD16(rwl_dec_add16),
+        .DEMUX_ADD1   (demux_add1),     .DEMUX_ADD2   (demux_add2),
+        .DEMUX_ADD3   (demux_add3),     .DEMUX_ADD4   (demux_add4),
+        .DEMUX_ADD5   (demux_add5),     .DEMUX_ADD6   (demux_add6),
+        .DEMUX_ADD7   (demux_add7),     .DEMUX_ADD8   (demux_add8),
+        .DEMUX_ADD9   (demux_add9),     .DEMUX_ADD10  (demux_add10),
+        .DEMUX_ADD11  (demux_add11),    .DEMUX_ADD12  (demux_add12),
+        .DEMUX_ADD13  (demux_add13),    .DEMUX_ADD14  (demux_add14),
+        .DEMUX_ADD15  (demux_add15),    .DEMUX_ADD16  (demux_add16),
+        .DEMUX_ADD_3  (demux_add_3),
+        .DRAM_DATA_OUT(dram_byte),
+        .RD_DONE      (rd_done),
+        .DRAM16_data  (DRAM16_data),
+        .PC_data      (pc_data_w),
+        .ADD_IN       (add_in_w),
+        .ADD_VALID_IN (add_vld_w),
+        .PC_D_IN      (pc_d_in_w),
+        .D_IN         (dram_din_w),
+        .DATA_VALID_IN(data_vld_w),
+        .clk_out      (clk_out_w),
+        .WRI_EN       (wri_en_w),
+        .R_AD         (dram_rad_w),
+        .PC_R_AD      (pc_r_ad_w),
+        .LIM_IN       (dram_lim_w),
+        .LIM_SEL      (lim_sel_w),
+        .DE_ADD3      (dmx2_w),
+        .RD_EN        (rd_en_w),
+        .VSAEN        (vsaen_w),
+        .REF_WWL      (ref_wwl_w)
+    );
+
+    // Drive top-level outputs directly from DRAM controller
+    assign ADDIN_1v8   = add_in_w;
+    assign ADVLD_1v8   = add_vld_w;
+    assign DVLD_1v8    = data_vld_w;
+    assign CLK_chip_1v8 = clk_out_w;
+    assign WRIEN_1v8   = wri_en_w;
+    assign RDEN_1v8    = rd_en_w;
+    assign VSAEN_1v8   = vsaen_w;
+    assign REFWWL_1v8  = ref_wwl_w;
+    assign DMX2_1v8    = dmx2_w;
+    assign LIMSEL0_1v8 = lim_sel_w[0];
+    assign LIMSEL1_1v8 = lim_sel_w[1];
+
+    assign {CINH_ps_1v8, SR_ps_1v8, CLK_ps_1v8} = pc_data_w;
+    assign {CLRb_spw_1v8, CLK_spw_1v8} = pc_d_in_w;
+    assign {CLRb_spr_1v8, CLK_spr_1v8} = pc_r_ad_w;
 
     assign {RAD_1v8_16, RAD_1v8_15, RAD_1v8_14, RAD_1v8_13,
             RAD_1v8_12, RAD_1v8_11, RAD_1v8_10, RAD_1v8_9,
             RAD_1v8_8,  RAD_1v8_7,  RAD_1v8_6,  RAD_1v8_5,
-            RAD_1v8_4,  RAD_1v8_3,  RAD_1v8_2,  RAD_1v8_1} =
-           init_active ? init_dram_rad : aes_dram_rad;
+            RAD_1v8_4,  RAD_1v8_3,  RAD_1v8_2,  RAD_1v8_1} = dram_rad_w;
     assign {DIN_1v8_16, DIN_1v8_15, DIN_1v8_14, DIN_1v8_13,
             DIN_1v8_12, DIN_1v8_11, DIN_1v8_10, DIN_1v8_9,
             DIN_1v8_8,  DIN_1v8_7,  DIN_1v8_6,  DIN_1v8_5,
-            DIN_1v8_4,  DIN_1v8_3,  DIN_1v8_2,  DIN_1v8_1} =
-           init_active ? init_dram_din : aes_dram_din;
+            DIN_1v8_4,  DIN_1v8_3,  DIN_1v8_2,  DIN_1v8_1} = dram_din_w;
     assign {LIMIN_1v8_16, LIMIN_1v8_15, LIMIN_1v8_14, LIMIN_1v8_13,
             LIMIN_1v8_12, LIMIN_1v8_11, LIMIN_1v8_10, LIMIN_1v8_9,
             LIMIN_1v8_8,  LIMIN_1v8_7,  LIMIN_1v8_6,  LIMIN_1v8_5,
-            LIMIN_1v8_4,  LIMIN_1v8_3,  LIMIN_1v8_2,  LIMIN_1v8_1} =
-           init_active ? init_dram_lim : aes_dram_lim;
+            LIMIN_1v8_4,  LIMIN_1v8_3,  LIMIN_1v8_2,  LIMIN_1v8_1} = dram_lim_w;
 
     // output signals following the required interface naming
 


### PR DESCRIPTION
## Summary
- Multiplex initialization and AES signals to a single DRAM_write_read_16core controller
- Remove duplicate DRAM controller instance and route outputs directly to top-level pins

## Testing
- `iverilog -tnull AES_DRAM_Top.v DRAM_Write_read_16core_v2.v DRAM_Key_Sbox_Init.v StdAES_Optimized.v StdAES_Optimized_AES_Core.v StdAES_Optimized_MixColumns.v` *(command not found)*
- `apt-get update` *(403: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b02d6d4eec8322be00730bcc77a82a