### PR TITLE
Fix AES key expansion sub_word byte order

### DIFF
--- a/wbl_key_gen.v
+++ b/wbl_key_gen.v
@@ -126,7 +126,10 @@ module wbl_key_gen(
 
     function [31:0] sub_word;
         input [31:0] w;
-        sub_word = {sbox(w[23:16]), sbox(w[15:8]), sbox(w[7:0]), sbox(w[31:24])};
+        // Apply the AES S-box to each byte of the word without altering
+        // the byte ordering. The previous implementation rotated the bytes
+        // a second time which produced incorrect round keys.
+        sub_word = {sbox(w[31:24]), sbox(w[23:16]), sbox(w[15:8]), sbox(w[7:0])};
     endfunction
 
     // ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- correct sub_word function in `wbl_key_gen` to maintain byte order when applying S-box
- add comment explaining previous rotation bug that produced incorrect round keys

## Testing
- ❌ `iverilog -g2012 wbl_key_gen_tb.v -o wbl_key_gen_tb.out` (iverilog not installed)
- ⚠️ `apt-get update` (403 Forbidden when attempting to install dependencies)

------
https://chatgpt.com/codex/tasks/task_e_68b1587194088322be67a21bb5185088