### PR TITLE
Remove unused key connection from AES top

### DIFF
--- a/AES_DRAM_Top.v
+++ b/AES_DRAM_Top.v
@@ -152,7 +152,6 @@ module AES_DRAM_Top(
         .RSTn  (RSTn),
         .EN    (EN && init_done),
         .Din   (Din),
-        .Kin   (Kin),
         .KDrdy (Kdrdy),
         .RIO_00(dram_byte1), .RIO_01(dram_byte2), .RIO_02(dram_byte3), .RIO_03(dram_byte4),
         .RIO_04(dram_byte5), .RIO_05(dram_byte6), .RIO_06(dram_byte7), .RIO_07(dram_byte8),


### PR DESCRIPTION
## Summary
- fix port mismatch by dropping unused `Kin` connection when instantiating `StdAES_Optimized`

## Testing
- `iverilog -g2012 -o sim AES_DRAM_Top_tb.v AES_DRAM_Top.v StdAES_Optimized.v StdAES_Optimized_AES_Core.v StdAES_Optimized_MixColumns.v DRAM_Key_Sbox_Init.v DRAM_Write_read_16core_v2.v wbl_key_gen.v` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b16d4f5f308322a03c2711a30d3398