### PR TITLE
Replace AES core with DRAM CIM unit and merge top level

### DIFF
--- a/AES_DRAM_ARTY7_TOP.v
+++ b/AES_DRAM_ARTY7_TOP.v
@@ -3,7 +3,6 @@
 // Final top-level integrating UART interface with DRAM CIM-based AES core.
 module AES_DRAM_ARTY7_TOP(
     // UART interface
-    input  wire         CLK,
     input  wire         NRST,
     input  wire         RX_UART,
     output wire         TX_UART,
@@ -110,6 +109,7 @@ module AES_DRAM_ARTY7_TOP(
 );
 
     // Wires between UART controller and DRAM AES core
+    wire        CLK;        // buffered clock from differential input
     wire        aes_bsy;
     wire [127:0] aes_dout;
     wire        aes_dvld;
@@ -121,6 +121,16 @@ module AES_DRAM_ARTY7_TOP(
     wire        rstn_aes;
     wire        CLK_int;
     wire        trigger;
+
+    IBUFDS #(
+        .DIFF_TERM ("FALSE"),
+        .IBUF_LOW_PWR("TRUE"),
+        .IOSTANDARD("DEFAULT")
+    ) IBUFDS_inst (
+        .O (CLK),
+        .I (CLK_p),
+        .IB(CLK_n)
+    );
 
     // UART to AES controller
     clk_gen_uart_wrapper clk_gen_intf_0(
@@ -142,8 +152,7 @@ module AES_DRAM_ARTY7_TOP(
 
     // DRAM CIM-based AES core
     AES_DRAM_Top aes_dram_0(
-        .CLK_p(CLK_p),
-        .CLK_n(CLK_n),
+        .CLK(CLK),
         .RSTn(rstn_aes),
         .EN(en_aes),
         .Din(din_aes),

--- a/AES_DRAM_Top.v
+++ b/AES_DRAM_Top.v
@@ -2,8 +2,7 @@
 // controller.  External interface follows the naming and timing
 // convention described in the specification table and waveform.
 module AES_DRAM_Top(
-    input wire CLK_p,
-    input wire CLK_n,
+    input wire CLK,
     input wire RSTn,
     input wire EN,
     input wire [127:0] Din,
@@ -112,7 +111,6 @@ module AES_DRAM_Top(
     output wire         LIMIN_1v8_16
 
 );
-    wire         CLK;
 
     wire clk_400m;
     wire clk_100m;
@@ -162,16 +160,6 @@ module AES_DRAM_Top(
     wire [63:0] init_wbl_data [0:15];
 (* mark_debug = "true" *)    wire        init_done;
 	wire        aes_io_en;
-
-    IBUFDS #(
-        .DIFF_TERM ("FALSE"),
-        .IBUF_LOW_PWR("TRUE"),
-        .IOSTANDARD("DEFAULT")
-    ) IBUFDS_inst (
-        .O (CLK),
-        .I (CLK_p),
-        .IB(CLK_n)
-    );
 
     clk_wiz_400m u_clk_wiz_400m(
          .clk_400m(clk_400m),

--- a/AES_DRAM_Top_tb.v
+++ b/AES_DRAM_Top_tb.v
@@ -12,9 +12,8 @@
 // a starting point for further development.
 
 module AES_DRAM_Top_tb;
-    // differential clock and reset
-    reg CLK_p;            // positive clock from the differential pair
-    wire CLK_n = ~CLK_p;  // generate the negative clock
+    // clock and reset
+    reg CLK;              // 100 MHz clock
     reg RSTn;
 
     // top-level inputs
@@ -50,8 +49,7 @@ module AES_DRAM_Top_tb;
 
     // instantiate design under test
     AES_DRAM_Top dut (
-        .CLK_p      (CLK_p),
-        .CLK_n      (CLK_n),
+        .CLK        (CLK),
         .RSTn       (RSTn),
         .EN         (EN),
 //        .Kin        (Kin),
@@ -108,8 +106,8 @@ module AES_DRAM_Top_tb;
     );
 
     // clock generation
-    initial CLK_p = 0;
-    always #5 CLK_p = ~CLK_p; // 100 MHz differential clock
+    initial CLK = 0;
+    always #5 CLK = ~CLK; // 100 MHz clock
 
     // stimulus
     initial begin


### PR DESCRIPTION
## Summary
- expose `AES_DRAM_Top` ports for UART-supplied key, data, and control
- feed runtime `Din`/`Kin` into AES and initialization logic
- consolidate UART interface and DRAM CIM core into `AES_DRAM_ARTY7_TOP`

## Testing
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y iverilog` *(fails: package not found)*
- `iverilog -tnull AES_DRAM_ARTY7_TOP.v AES_DRAM_Top.v DRAM_Write_read_16core_v2.v DRAM_Key_Sbox_Init.v StdAES_Optimized.v StdAES_Optimized_AES_Core.v StdAES_Optimized_MixColumns.v wbl_key_gen.v -I .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b1ad1ae883228ff2c88edc740bd2