### PR TITLE
Prevent repeated DRAM key/SBOX initialization

### DIFF
--- a/DRAM_Key_Sbox_Init.v
+++ b/DRAM_Key_Sbox_Init.v
@@ -82,6 +82,7 @@ module DRAM_Key_Sbox_Init (
 
     reg        active;
     reg        gen_active;
+    reg        configured;
     reg [5:0]  addr_reg;
     reg [63:0] data1_reg, data2_reg, data3_reg, data4_reg;
     reg [63:0] data5_reg, data6_reg, data7_reg, data8_reg;
@@ -113,6 +114,7 @@ module DRAM_Key_Sbox_Init (
         if (!RSTn) begin
             active     <= 1'b0;
             gen_active <= 1'b0;
+            configured <= 1'b0;
             addr_reg   <= 6'd0;
             DONE       <= 1'b0;
             IO_EN      <= 1'b0;
@@ -134,7 +136,7 @@ module DRAM_Key_Sbox_Init (
             data16_reg <= 64'h0;
         end else begin
             IO_EN <= 1'b0; // default low, pulse when starting a write
-            if (START && !gen_active && !active) begin
+            if (START && !gen_active && !active && !configured) begin
                 // initiate key expansion
                 gen_active <= 1'b1;
                 DONE       <= 1'b0;
@@ -163,8 +165,9 @@ module DRAM_Key_Sbox_Init (
             end else if (active && wr_done) begin
                 if (addr_reg == LAST_ADDR) begin
                     // finished streaming all addresses
-                    active <= 1'b0;
-                    DONE   <= 1'b1;
+                    active     <= 1'b0;
+                    DONE       <= 1'b1;
+                    configured <= 1'b1;
                 end else begin
                     addr_reg  <= addr_reg + 1'b1;
                     IO_EN     <= 1'b1; // pulse for subsequent write


### PR DESCRIPTION
## Summary
- add `configured` flag to DRAM_Key_Sbox_Init to avoid repeated programming
- block `START` after first initialization and mark completion when final address written

## Testing
- `iverilog -g2012 -o sim_AES_DRAM_SCA_TOP_tb AES_DRAM_SCA_TOP_tb.v AES_DRAM_SCA_TOP.v AES_DRAM_SCA_TOP_tb.v DRAM_Key_Sbox_Init.v DRAM_Write_read_16core_v2.v StdAES_Optimized.v StdAES_Optimized_AES_Core.v StdAES_Optimized_MixColumns.v UART_Interface_Controller.v clk_gen_uart.v clk_gen_uart_UART_Interface_Contr_0_1.v clk_gen_uart_wrapper.v wbl_key_gen.v` *(command failed: `iverilog` not found)*
- `apt-get update >/tmp/apt_update.log && tail -n 20 /tmp/apt_update.log` *(permission denied: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd80931908322a252fd35191a369d