### PR TITLE
Retime DATA_VALID_IN hold and address launch delay

### DIFF
--- a/DRAM_Write_read_16core_v2.v
+++ b/DRAM_Write_read_16core_v2.v
@@ -565,7 +565,7 @@ module DRAM_write_read_16core(
             end
             else begin
                 // 写入数据
-                if ( (counter_work >= 13'd1645) && (IO_MODEL_r == 2'b01) ) begin
+                if ( (counter_work >= 13'd1679) && (IO_MODEL_r == 2'b01) ) begin
                     IO_EN_FLAG <= 1'b0;
                 end
                 // 读出数据
@@ -851,6 +851,12 @@ module DRAM_write_read_16core(
                             clk_out_WT <= 1'b1; DATA_VALID_IN <= 1'b0; // 保持使能
                         end
                 13'd196: begin
+                            clk_out_WT <= 1'b0; DATA_VALID_IN <= 1'b0; // 延长低电平保持
+                        end
+                13'd198: begin
+                            clk_out_WT <= 1'b0; DATA_VALID_IN <= 1'b0; // 继续延长低电平保持
+                        end
+                13'd200: begin
                             clk_out_WT <= 1'b0; DATA_VALID_IN <= 1'b1; // 停止
                         end
                 // ================= 第 2 轮（索引 1,9,17,25,33,41,49,57） =================
@@ -1029,7 +1035,10 @@ module DRAM_write_read_16core(
                             clk_out_WT <= 1'b1; DATA_VALID_IN <= 1'b0; // 保持使能  
                         end
                 13'd398: begin
-                            clk_out_WT <= 1'b0; DATA_VALID_IN <= 1'b1; // 停止
+                            clk_out_WT <= 1'b0; DATA_VALID_IN <= 1'b0; // 延长低电平保持
+                        end
+                13'd400: begin
+                            clk_out_WT <= 1'b0; DATA_VALID_IN <= 1'b0; // 继续延长低电平保持
                         end
                 // ================= 第 3 轮（索引 2,10,18,26,34,42,50,58） =================
                 13'd402:   begin
@@ -1207,6 +1216,12 @@ module DRAM_write_read_16core(
                             clk_out_WT <= 1'b1; DATA_VALID_IN <= 1'b0; // 保持使能  
                         end
                 13'd598: begin
+                            clk_out_WT <= 1'b0; DATA_VALID_IN <= 1'b0; // 延长低电平保持
+                        end
+                13'd600: begin
+                            clk_out_WT <= 1'b0; DATA_VALID_IN <= 1'b0; // 继续延长低电平保持
+                        end
+                13'd602: begin
                             clk_out_WT <= 1'b0; DATA_VALID_IN <= 1'b1; // 停止
                         end
                 // ================= 第 4 轮（索引 3,11,19,27,35,43,51,59） =================
@@ -1385,6 +1400,12 @@ module DRAM_write_read_16core(
                             clk_out_WT <= 1'b1; DATA_VALID_IN <= 1'b0; // 保持使能  
                         end
                 13'd799: begin
+                            clk_out_WT <= 1'b0; DATA_VALID_IN <= 1'b0; // 延长低电平保持
+                        end
+                13'd801: begin
+                            clk_out_WT <= 1'b0; DATA_VALID_IN <= 1'b0; // 继续延长低电平保持
+                        end
+                13'd803: begin
                             clk_out_WT <= 1'b0; DATA_VALID_IN <= 1'b1; // 停止
                         end
                 // ================= 第 5 轮（索引 4,12,20,28,36,44,52,60） =================
@@ -1563,6 +1584,12 @@ module DRAM_write_read_16core(
                             clk_out_WT <= 1'b1; DATA_VALID_IN <= 1'b0; // 保持使能  
                         end
                 13'd1000: begin
+                            clk_out_WT <= 1'b0; DATA_VALID_IN <= 1'b0; // 延长低电平保持
+                        end
+                13'd1002: begin
+                            clk_out_WT <= 1'b0; DATA_VALID_IN <= 1'b0; // 继续延长低电平保持
+                        end
+                13'd1004: begin
                             clk_out_WT <= 1'b0; DATA_VALID_IN <= 1'b1; // 停止
                         end
                 // ================= 第 6 轮（索引 5,13,21,29,37,45,53,61） =================
@@ -1741,6 +1768,12 @@ module DRAM_write_read_16core(
                             clk_out_WT <= 1'b1; DATA_VALID_IN <= 1'b0; // 保持使能  
                         end
                 13'd1200: begin
+                            clk_out_WT <= 1'b0; DATA_VALID_IN <= 1'b0; // 延长低电平保持
+                        end
+                13'd1202: begin
+                            clk_out_WT <= 1'b0; DATA_VALID_IN <= 1'b0; // 继续延长低电平保持
+                        end
+                13'd1204: begin
                             clk_out_WT <= 1'b0; DATA_VALID_IN <= 1'b1; // 停止
                         end
                 // ================= 第 7 轮（索引 6,14,22,30,38,46,54,62） =================
@@ -1919,6 +1952,12 @@ module DRAM_write_read_16core(
                             clk_out_WT <= 1'b1; DATA_VALID_IN <= 1'b0; // 保持使能  
                         end
                 13'd1402: begin
+                            clk_out_WT <= 1'b0; DATA_VALID_IN <= 1'b0; // 延长低电平保持
+                        end
+                13'd1404: begin
+                            clk_out_WT <= 1'b0; DATA_VALID_IN <= 1'b0; // 继续延长低电平保持
+                        end
+                13'd1406: begin
                             clk_out_WT <= 1'b0; DATA_VALID_IN <= 1'b1; // 停止
                         end
                 // ================= 第 8 轮（索引 7,15,23,31,39,47,55,63） =================
@@ -2090,79 +2129,94 @@ module DRAM_write_read_16core(
                 13'd1598: begin PC_D_IN[0] <= 1'b0; end
 
                 // ================= 第二层并转串--单次写周期 =================
-                13'd1599: begin 
-                            clk_out_WT <= 1'b0; DATA_VALID_IN <= 1'b0; // 使能串转并  
+                13'd1599: begin
+                            clk_out_WT <= 1'b0; DATA_VALID_IN <= 1'b0; // 使能串转并
                         end
                 13'd1601: begin
-                            clk_out_WT <= 1'b1; DATA_VALID_IN <= 1'b0; // 保持使能  
+                            clk_out_WT <= 1'b1; DATA_VALID_IN <= 1'b0; // 保持使能
                         end
                 13'd1603: begin
-                            clk_out_WT <= 1'b0; DATA_VALID_IN <= 1'b1; // 停止数据准备
-                            // 输入地址的串转并
-                            ADD_IN <= WWL_ADD_r[5]; ADD_VALID_IN <= 1'b0;// 有效是低电平
+                            clk_out_WT <= 1'b0; DATA_VALID_IN <= 1'b0; // 延长低电平保持
                         end
-                // 完成输入数据的串转并
-                // 准备输入地址的串转并
                 13'd1605: begin
-                            clk_out_WT <= 1'b1;
+                            clk_out_WT <= 1'b0; DATA_VALID_IN <= 1'b0; // 继续延长低电平保持
                         end
                 13'd1607: begin
-                            clk_out_WT <= 1'b0;
-                            ADD_IN <= WWL_ADD_r[4];
+                            clk_out_WT <= 1'b0; DATA_VALID_IN <= 1'b1; // 停止数据准备
                         end
-                13'd1609: begin
-                            clk_out_WT <= 1'b1;
-                        end
-                13'd1611: begin
-                            clk_out_WT <= 1'b0;
-                            ADD_IN <= WWL_ADD_r[3];
-                        end
-                13'd1613: begin
-                            clk_out_WT <= 1'b1;
-                        end
-                13'd1615: begin
-                            clk_out_WT <= 1'b0;
-                            ADD_IN <= WWL_ADD_r[2];
-                        end
-                13'd1617: begin
-                            clk_out_WT <= 1'b1;
-                        end
-                13'd1619: begin
-                            clk_out_WT <= 1'b0;
-                            ADD_IN <= WWL_ADD_r[1];
-                        end
-                13'd1621: begin
-                            clk_out_WT <= 1'b1;
-                        end
-                13'd1623: begin
-                            clk_out_WT <= 1'b0;
-                            ADD_IN <= WWL_ADD_r[0];
-                        end
-                13'd1625: begin
-                            clk_out_WT <= 1'b1;
-                        end
-                13'd1626: begin
-                            WRI_EN<=1;
-                        end
+                // 完成输入数据的串转并
+                // 准备输入地址的串转并（延迟20个周期）
                 13'd1627: begin
+                            ADD_IN <= WWL_ADD_r[5]; ADD_VALID_IN <= 1'b0;// 有效是低电平
                             clk_out_WT <= 1'b0;
-                            ADD_VALID_IN <= 1'b1;// 结束地址移位
-                            WRI_EN<=1;
                         end
                 13'd1629: begin
-                            clk_out_WT <= 1'b1; //修改为0
-                            //
+                            clk_out_WT <= 1'b1;
                         end
                 13'd1631: begin
                             clk_out_WT <= 1'b0;
+                            ADD_IN <= WWL_ADD_r[4];
                         end
-                13'd1633: begin clk_out_WT <= 1'b1; WRI_EN<=1;end
-                13'd1635: begin clk_out_WT <= 1'b0; WRI_EN<=0;WR_flag<=0;end
-                13'd1637: begin end
-                13'd1639: begin end
-                13'd1641: begin WRI_EN<=0; WR_flag<=0; end
-                13'd1643: begin  WT_DONE_r <= 1; end
-                13'd1644: begin  WT_DONE_r <= 0; end
+                13'd1633: begin
+                            clk_out_WT <= 1'b1;
+                        end
+                13'd1635: begin
+                            clk_out_WT <= 1'b0;
+                            ADD_IN <= WWL_ADD_r[3];
+                        end
+                13'd1637: begin
+                            clk_out_WT <= 1'b1;
+                        end
+                13'd1639: begin
+                            clk_out_WT <= 1'b0;
+                            ADD_IN <= WWL_ADD_r[2];
+                        end
+                13'd1641: begin
+                            clk_out_WT <= 1'b1;
+                        end
+                13'd1643: begin
+                            clk_out_WT <= 1'b0;
+                            ADD_IN <= WWL_ADD_r[1];
+                        end
+                13'd1645: begin
+                            clk_out_WT <= 1'b1;
+                        end
+                13'd1647: begin
+                            clk_out_WT <= 1'b0;
+                            ADD_IN <= WWL_ADD_r[0];
+                        end
+                13'd1649: begin
+                            clk_out_WT <= 1'b1;
+                        end
+                13'd1651: begin
+                            clk_out_WT <= 1'b0;
+                            ADD_VALID_IN <= 1'b1;// 结束地址移位
+                        end
+                13'd1660: begin
+                            WRI_EN<=1;
+                        end
+                13'd1661: begin
+                            clk_out_WT <= 1'b0;
+                            ADD_VALID_IN <= 1'b1;
+                            WRI_EN<=1;
+                        end
+                13'd1663: begin
+                            clk_out_WT <= 1'b1; //修改为0
+                        end
+                13'd1665: begin
+                            clk_out_WT <= 1'b0;
+                        end
+                13'd1667: begin
+                            clk_out_WT <= 1'b1; WRI_EN<=1;
+                        end
+                13'd1669: begin
+                            clk_out_WT <= 1'b0; WRI_EN<=0;WR_flag<=0;
+                        end
+                13'd1671: begin end
+                13'd1673: begin end
+                13'd1675: begin WRI_EN<=0; WR_flag<=0; end
+                13'd1677: begin  WT_DONE_r <= 1; end
+                13'd1678: begin  WT_DONE_r <= 0; end
                 default: begin end
                 endcase
             end


### PR DESCRIPTION
## Summary
- extend the write data serialization stage to hold DATA_VALID_IN low for two additional counter_work cycles before releasing the bus
- start the ADD_VALID_IN/ADD_IN shifting sequence 20 counter_work cycles after DATA_VALID_IN finishes and retime the subsequent WRI_EN and done phases to match the new schedule
- move the IO_EN_FLAG drop threshold to the new end-of-write cycle so the controller stays active through the longer sequence

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d3ae01a45483229fa66d54f2cf92bb